### PR TITLE
Fix countdown bug in St. Patty site

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,24 +159,28 @@
         }
 
         // Countdown Timer Function
+        let countdownInterval;
         function updateCountdown() {
             const stPatricksDay = new Date("March 17, 2025 00:00:00").getTime();
             const now = new Date().getTime();
             const timeLeft = stPatricksDay - now;
 
             if (timeLeft > 0) {
-                const hours = Math.floor(timeLeft / (1000 * 60 * 60));
+                const days = Math.floor(timeLeft / (1000 * 60 * 60 * 24));
+                const hours = Math.floor((timeLeft % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
                 const minutes = Math.floor((timeLeft % (1000 * 60 * 60)) / (1000 * 60));
                 const seconds = Math.floor((timeLeft % (1000 * 60)) / 1000);
 
-                document.getElementById("countdown").innerHTML = `Time until St. Patrick’s Day: <b>${hours} hours, ${minutes} minutes, ${seconds} seconds</b> ⏳`;
+                document.getElementById("countdown").innerHTML =
+                    `Time until St. Patrick’s Day: <b>${days} days, ${hours} hours, ${minutes} minutes, ${seconds} seconds</b> ⏳`;
             } else {
                 document.getElementById("countdown").innerHTML = "Happy St. Patrick’s Day! 🎉🍀";
+                clearInterval(countdownInterval);
             }
         }
 
         // Update countdown every second
-        setInterval(updateCountdown, 1000);
+        countdownInterval = setInterval(updateCountdown, 1000);
         updateCountdown(); // Run immediately
     </script>
 </body>


### PR DESCRIPTION
## Summary
- improve the countdown timer
  - display days as well as hours/minutes/seconds
  - stop the timer after St. Patrick's Day has arrived

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68407d826e0c8331901bdccc3069ef49