### PR TITLE
Fix repeated rain effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,9 @@
         }
 
         function startRain() {
+            // Clear any existing drops before creating new ones
+            removeRain();
+
             for (let i = 0; i < 50; i++) { // Number of rain drops
                 let drop = document.createElement("div");
                 drop.classList.add("rain-drop");


### PR DESCRIPTION
## Summary
- call `removeRain()` before creating rain drops so the drop count doesn't grow

## Testing
- `node verify.js` *(fails: Could not load style due to network, but demonstrates 50 drops after each startRain call)*

------
https://chatgpt.com/codex/tasks/task_e_68407ec2da008331b51c6285686b836f